### PR TITLE
Reading Lazy.Value lazily instead of during static field initialization

### DIFF
--- a/Analogy/Managers/AnalogyNonPersistSettings.cs
+++ b/Analogy/Managers/AnalogyNonPersistSettings.cs
@@ -9,7 +9,7 @@ namespace Analogy.Managers
     {
         private static readonly Lazy<AnalogyNonPersistSettings> _instance =
             new Lazy<AnalogyNonPersistSettings>(() => new AnalogyNonPersistSettings());
-        public static AnalogyNonPersistSettings Instance { get; set; } = _instance.Value;
+        public static AnalogyNonPersistSettings Instance => _instance.Value;
         private static string AnalogyRegistryKey => @"SOFTWARE\Analogy.LogViewer";
         public List<string> AdditionalAssembliesDependenciesLocations { get; }
         public bool DisableUpdatesByDataProvidersOverrides { get; set; }

--- a/Analogy/Managers/ClientServerDataSourceManager.cs
+++ b/Analogy/Managers/ClientServerDataSourceManager.cs
@@ -9,7 +9,7 @@ namespace Analogy
     {
         private string FileName { get; } = "ExternalLocations.dat";
         private static readonly Lazy<ClientServerDataSourceManager> _instance = new Lazy<ClientServerDataSourceManager>(() => new ClientServerDataSourceManager());
-        public static ClientServerDataSourceManager Instance { get; } = _instance.Value;
+        public static ClientServerDataSourceManager Instance => _instance.Value;
         public List<DataSource> DataSources { get; } = new List<DataSource>();
 
         public ClientServerDataSourceManager()

--- a/Analogy/Managers/FactoriesManager.cs
+++ b/Analogy/Managers/FactoriesManager.cs
@@ -19,7 +19,7 @@ namespace Analogy
             _instance = new Lazy<FactoriesManager>(() => new FactoriesManager());
 
         public List<string> ProbingPaths { get; set; } = new List<string>();
-        public static readonly FactoriesManager Instance = _instance.Value;
+        public static FactoriesManager Instance => _instance.Value;
         public List<FactoryContainer> BuiltInFactories { get; }
         public List<FactoryContainer> Factories { get; }
 

--- a/Analogy/Managers/FileProcessingManager.cs
+++ b/Analogy/Managers/FileProcessingManager.cs
@@ -8,7 +8,7 @@ namespace Analogy
     public class FileProcessingManager
     {
         private static readonly Lazy<FileProcessingManager> _instance = new Lazy<FileProcessingManager>(() => new FileProcessingManager());
-        public static FileProcessingManager Instance { get; } = _instance.Value;
+        public static FileProcessingManager Instance => _instance.Value;
 
         private List<string> ProcessedFileNames { get; set; } = new List<string>();
         private List<string> Processing { get; set; } = new List<string>();

--- a/Analogy/Managers/UpdateManager.cs
+++ b/Analogy/Managers/UpdateManager.cs
@@ -21,7 +21,7 @@ namespace Analogy.Managers
             _instance = new Lazy<UpdateManager>(() => new UpdateManager());
 
         private UserSettingsManager Settings => UserSettingsManager.UserSettings;
-        public static readonly UpdateManager Instance = _instance.Value;
+        public static UpdateManager Instance => _instance.Value;
         private string repository = @"https://api.github.com/repos/Analogy-LogViewer/Analogy.LogViewer";
         public bool EnableUpdate => UpdateMode != UpdateMode.Never;
         private string updaterRepository = @"https://api.github.com/repos/Analogy-LogViewer/Analogy.Updater";

--- a/Analogy/Managers/UserSettingsManager.cs
+++ b/Analogy/Managers/UserSettingsManager.cs
@@ -22,8 +22,7 @@ namespace Analogy
     {
         public event EventHandler OnFactoryOrderChanged;
 
-        private static readonly Lazy<UserSettingsManager> _instance =
-            new Lazy<UserSettingsManager>(() => new UserSettingsManager());
+        private static UserSettingsManager? _userSettings;
 
         private CommandLayout _ribbonStyle;
         private bool _enableFirstChanceException;
@@ -33,7 +32,16 @@ namespace Analogy
         public string DisplayRunningTime => $"{AnalogyRunningTime:dd\\.hh\\:mm\\:ss} days";
         public Guid InitialSelectedDataProvider { get; set; } = new Guid("D3047F5D-CFEB-4A69-8F10-AE5F4D3F2D04");
         public string ApplicationSkinName { get; set; }
-        public static UserSettingsManager UserSettings { get; set; } = _instance.Value;
+
+        /// <remarks>
+        /// Manually implemented lazy pattern to enable setting while keeping the ctor in the getter lazy.
+        /// </remarks>
+        public static UserSettingsManager UserSettings
+        {
+            get => _userSettings ??= new UserSettingsManager();
+            set => _userSettings = value;
+        }
+
         public bool SaveSearchFilters { get; set; }
         public string IncludeText { get; set; }
         public string ExcludeText { get; set; }


### PR DESCRIPTION
When Analogy.UserSettingsManager.ApplyLocalSettings should be called, during the startup of a portable version containing an AnalogyLocalSettings.json, some native code instead starts to initialize static fields.
One such filed is Analogy.FactoriesManager.Instance.
Because Analogy.FactoriesManager..ctor calls Analogy.UserSettingsManager.UserSettings, which is currently beeing initialized and not set jet, a System.NullReferenceException is thrown.


Debugged with net471:

System.NullReferenceException
  HResult=0x80004003
  Message=Der Objektverweis wurde nicht auf eine Objektinstanz festgelegt.
  Source=Analogy
  StackTrace:
   at Analogy.FactoriesManager..ctor() in C:\git\repos\Analogy.LogViewer\Analogy\Managers\FactoriesManager.cs:line 33

Callstack:
>	Analogy.exe!Analogy.FactoriesManager.FactoriesManager() Line 33	C#
 	Analogy.exe!Analogy.FactoriesManager..cctor.AnonymousMethod__29_0() Line 19	C#
 	mscorlib.dll!System.Lazy<Analogy.FactoriesManager>.CreateValue()	Unknown
 	mscorlib.dll!System.Lazy<Analogy.FactoriesManager>.LazyInitValue()	Unknown
 	Analogy.exe!Analogy.FactoriesManager.FactoriesManager() Line 22	C#
 	[Native to Managed Transition]	
 	[Managed to Native Transition]	
 	mscorlib.dll!System.AppDomain.OnAssemblyResolveEvent(System.Reflection.RuntimeAssembly assembly, string assemblyFullName)	Unknown
 	[Native to Managed Transition]	
 	[Managed to Native Transition]	
 	mscorlib.dll!System.Reflection.RuntimeAssembly.InternalGetSatelliteAssembly(string name, System.Globalization.CultureInfo culture, System.Version version, bool throwOnFileNotFound, ref System.Threading.StackCrawlMark stackMark)	Unknown
 	mscorlib.dll!System.Resources.ManifestBasedResourceGroveler.GetSatelliteAssembly(System.Globalization.CultureInfo lookForCulture, ref System.Threading.StackCrawlMark stackMark)	Unknown
 	mscorlib.dll!System.Resources.ManifestBasedResourceGroveler.GrovelForResourceSet(System.Globalization.CultureInfo culture, System.Collections.Generic.Dictionary<string, System.Resources.ResourceSet> localResourceSets, bool tryParents, bool createIfNotExists, ref System.Threading.StackCrawlMark stackMark)	Unknown
 	mscorlib.dll!System.Resources.ResourceManager.InternalGetResourceSet(System.Globalization.CultureInfo requestedCulture, bool createIfNotExists, bool tryParents, ref System.Threading.StackCrawlMark stackMark)	Unknown
 	mscorlib.dll!System.Resources.ResourceManager.InternalGetResourceSet(System.Globalization.CultureInfo culture, bool createIfNotExists, bool tryParents)	Unknown
 	mscorlib.dll!System.Resources.ResourceManager.GetObject(string name, System.Globalization.CultureInfo culture, bool wrapUnmanagedMemStream)	Unknown
 	Analogy.exe!Analogy.Properties.Resources.serilog32x32.get() Line 1327	C#
 	Analogy.exe!Analogy.Managers.UpdateManager.UpdateManager() Line 117	C#
 	Analogy.exe!Analogy.Managers.UpdateManager..cctor.AnonymousMethod__52_0() Line 21	C#
 	mscorlib.dll!System.Lazy<Analogy.Managers.UpdateManager>.CreateValue()	Unknown
 	mscorlib.dll!System.Lazy<Analogy.Managers.UpdateManager>.LazyInitValue()	Unknown
 	Analogy.exe!Analogy.Managers.UpdateManager.UpdateManager() Line 24	C#
 	[Native to Managed Transition]	
 	[Managed to Native Transition]	
 	Analogy.exe!Analogy.UserSettingsManager.UserSettingsManager() Line 150	C#
 	Analogy.exe!Analogy.UserSettingsManager..cctor.AnonymousMethod__348_0() Line 26	C#
 	mscorlib.dll!System.Lazy<Analogy.UserSettingsManager>.CreateValue()	Unknown
 	mscorlib.dll!System.Lazy<Analogy.UserSettingsManager>.LazyInitValue()	Unknown
 	Analogy.exe!Analogy.UserSettingsManager.UserSettingsManager() Line 36	C#
 	[Native to Managed Transition]	
 	[Managed to Native Transition]	
 	Analogy.exe!Analogy.Program.Settings.get() Line 25	C#
 	Analogy.exe!Analogy.Program.Main() Line 45	C#

