### PR TITLE
Pooling for rolling files

### DIFF
--- a/Analogy/Forms/EditFilePooling.Designer.cs
+++ b/Analogy/Forms/EditFilePooling.Designer.cs
@@ -36,16 +36,19 @@
             // 
             // txtFilename
             // 
+            this.txtFilename.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.txtFilename.Location = new System.Drawing.Point(14, 52);
-            this.txtFilename.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.txtFilename.Margin = new System.Windows.Forms.Padding(4);
             this.txtFilename.Name = "txtFilename";
             this.txtFilename.Size = new System.Drawing.Size(904, 22);
             this.txtFilename.TabIndex = 0;
             // 
             // BtnOk
             // 
+            this.BtnOk.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.BtnOk.Location = new System.Drawing.Point(832, 95);
-            this.BtnOk.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.BtnOk.Margin = new System.Windows.Forms.Padding(4);
             this.BtnOk.Name = "BtnOk";
             this.BtnOk.Size = new System.Drawing.Size(88, 28);
             this.BtnOk.TabIndex = 1;
@@ -55,7 +58,7 @@
             // lblHelp
             // 
             this.lblHelp.Location = new System.Drawing.Point(14, 23);
-            this.lblHelp.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.lblHelp.Margin = new System.Windows.Forms.Padding(4);
             this.lblHelp.Name = "lblHelp";
             this.lblHelp.Size = new System.Drawing.Size(232, 16);
             this.lblHelp.TabIndex = 2;
@@ -66,16 +69,17 @@
             this.AcceptButton = this.BtnOk;
             this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(933, 138);
+            this.ClientSize = new System.Drawing.Size(933, 141);
             this.ControlBox = false;
             this.Controls.Add(this.lblHelp);
             this.Controls.Add(this.BtnOk);
             this.Controls.Add(this.txtFilename);
             this.IconOptions.ShowIcon = false;
-            this.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Margin = new System.Windows.Forms.Padding(4);
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "EditFilePooling";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Edit filename filter for pooling";
             ((System.ComponentModel.ISupportInitialize)(this.txtFilename.Properties)).EndInit();
             this.ResumeLayout(false);

--- a/Analogy/Forms/EditFilePooling.Designer.cs
+++ b/Analogy/Forms/EditFilePooling.Designer.cs
@@ -28,52 +28,56 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.txtFilename = new System.Windows.Forms.TextBox();
-            this.BtnOk = new System.Windows.Forms.Button();
-            this.lblHelp = new System.Windows.Forms.Label();
+            this.txtFilename = new DevExpress.XtraEditors.TextEdit();
+            this.BtnOk = new DevExpress.XtraEditors.SimpleButton();
+            this.lblHelp = new DevExpress.XtraEditors.LabelControl();
+            ((System.ComponentModel.ISupportInitialize)(this.txtFilename.Properties)).BeginInit();
             this.SuspendLayout();
             // 
             // txtFilename
             // 
-            this.txtFilename.Location = new System.Drawing.Point(12, 42);
+            this.txtFilename.Location = new System.Drawing.Point(14, 52);
+            this.txtFilename.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.txtFilename.Name = "txtFilename";
-            this.txtFilename.Size = new System.Drawing.Size(775, 20);
+            this.txtFilename.Size = new System.Drawing.Size(904, 22);
             this.txtFilename.TabIndex = 0;
             // 
             // BtnOk
             // 
-            this.BtnOk.Location = new System.Drawing.Point(713, 77);
+            this.BtnOk.Location = new System.Drawing.Point(832, 95);
+            this.BtnOk.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.BtnOk.Name = "BtnOk";
-            this.BtnOk.Size = new System.Drawing.Size(75, 23);
+            this.BtnOk.Size = new System.Drawing.Size(88, 28);
             this.BtnOk.TabIndex = 1;
             this.BtnOk.Text = "Ok";
-            this.BtnOk.UseVisualStyleBackColor = true;
             this.BtnOk.Click += new System.EventHandler(this.BtnOk_Click);
             // 
             // lblHelp
             // 
-            this.lblHelp.AutoSize = true;
-            this.lblHelp.Location = new System.Drawing.Point(12, 19);
+            this.lblHelp.Location = new System.Drawing.Point(14, 23);
+            this.lblHelp.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.lblHelp.Name = "lblHelp";
-            this.lblHelp.Size = new System.Drawing.Size(193, 13);
+            this.lblHelp.Size = new System.Drawing.Size(232, 16);
             this.lblHelp.TabIndex = 2;
             this.lblHelp.Text = "Add any needed * for rolling file scheme";
             // 
             // EditFilePooling
             // 
             this.AcceptButton = this.BtnOk;
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(800, 112);
+            this.ClientSize = new System.Drawing.Size(933, 138);
             this.ControlBox = false;
             this.Controls.Add(this.lblHelp);
             this.Controls.Add(this.BtnOk);
             this.Controls.Add(this.txtFilename);
+            this.IconOptions.ShowIcon = false;
+            this.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "EditFilePooling";
-            this.ShowIcon = false;
             this.Text = "Edit filename filter for pooling";
+            ((System.ComponentModel.ISupportInitialize)(this.txtFilename.Properties)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -81,8 +85,8 @@
 
         #endregion
 
-        private System.Windows.Forms.TextBox txtFilename;
-        private System.Windows.Forms.Button BtnOk;
-        private System.Windows.Forms.Label lblHelp;
+        private DevExpress.XtraEditors.TextEdit txtFilename;
+        private DevExpress.XtraEditors.SimpleButton BtnOk;
+        private DevExpress.XtraEditors.LabelControl lblHelp;
     }
 }

--- a/Analogy/Forms/EditFilePooling.Designer.cs
+++ b/Analogy/Forms/EditFilePooling.Designer.cs
@@ -1,0 +1,88 @@
+﻿namespace Analogy.Forms
+{
+    partial class EditFilePooling
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.txtFilename = new System.Windows.Forms.TextBox();
+            this.BtnOk = new System.Windows.Forms.Button();
+            this.lblHelp = new System.Windows.Forms.Label();
+            this.SuspendLayout();
+            // 
+            // txtFilename
+            // 
+            this.txtFilename.Location = new System.Drawing.Point(12, 42);
+            this.txtFilename.Name = "txtFilename";
+            this.txtFilename.Size = new System.Drawing.Size(775, 20);
+            this.txtFilename.TabIndex = 0;
+            // 
+            // BtnOk
+            // 
+            this.BtnOk.Location = new System.Drawing.Point(713, 77);
+            this.BtnOk.Name = "BtnOk";
+            this.BtnOk.Size = new System.Drawing.Size(75, 23);
+            this.BtnOk.TabIndex = 1;
+            this.BtnOk.Text = "Ok";
+            this.BtnOk.UseVisualStyleBackColor = true;
+            this.BtnOk.Click += new System.EventHandler(this.BtnOk_Click);
+            // 
+            // lblHelp
+            // 
+            this.lblHelp.AutoSize = true;
+            this.lblHelp.Location = new System.Drawing.Point(12, 19);
+            this.lblHelp.Name = "lblHelp";
+            this.lblHelp.Size = new System.Drawing.Size(193, 13);
+            this.lblHelp.TabIndex = 2;
+            this.lblHelp.Text = "Add any needed * for rolling file scheme";
+            // 
+            // EditFilePooling
+            // 
+            this.AcceptButton = this.BtnOk;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(800, 112);
+            this.ControlBox = false;
+            this.Controls.Add(this.lblHelp);
+            this.Controls.Add(this.BtnOk);
+            this.Controls.Add(this.txtFilename);
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "EditFilePooling";
+            this.ShowIcon = false;
+            this.Text = "Edit filename filter for pooling";
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.TextBox txtFilename;
+        private System.Windows.Forms.Button BtnOk;
+        private System.Windows.Forms.Label lblHelp;
+    }
+}

--- a/Analogy/Forms/EditFilePooling.cs
+++ b/Analogy/Forms/EditFilePooling.cs
@@ -1,0 +1,29 @@
+﻿using System.IO;
+using System.Windows.Forms;
+
+namespace Analogy.Forms
+{
+    public partial class EditFilePooling : Form
+    {
+        public EditFilePooling(string fileName)
+        {
+            InitializeComponent();
+            Dir = Path.GetDirectoryName(fileName) ?? string.Empty;
+            
+            txtFilename.Text = Path.GetFileName(fileName);
+        }
+        
+
+        public string Dir { get; set; }
+
+        public string Filter
+        {
+            get { return Path.Combine(Dir, txtFilename.Text); }
+        }
+
+        private void BtnOk_Click(object sender, System.EventArgs e)
+        {
+            Close();
+        }
+    }
+}

--- a/Analogy/Forms/EditFilePooling.cs
+++ b/Analogy/Forms/EditFilePooling.cs
@@ -3,23 +3,20 @@ using System.Windows.Forms;
 
 namespace Analogy.Forms
 {
-    public partial class EditFilePooling : Form
+    public partial class EditFilePooling : DevExpress.XtraEditors.XtraForm
     {
         public EditFilePooling(string fileName)
         {
             InitializeComponent();
+            Icon = UserSettingsManager.UserSettings.GetIcon();
             Dir = Path.GetDirectoryName(fileName) ?? string.Empty;
-            
             txtFilename.Text = Path.GetFileName(fileName);
         }
         
 
         public string Dir { get; set; }
 
-        public string Filter
-        {
-            get { return Path.Combine(Dir, txtFilename.Text); }
-        }
+        public string Filter => Path.Combine(Dir, txtFilename.Text);
 
         private void BtnOk_Click(object sender, System.EventArgs e)
         {

--- a/Analogy/Forms/EditFilePooling.resx
+++ b/Analogy/Forms/EditFilePooling.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/Analogy/Forms/FluentDesignMainForm.cs
+++ b/Analogy/Forms/FluentDesignMainForm.cs
@@ -1007,7 +1007,7 @@ namespace Analogy
                         if (openFileDialog1.ShowDialog() == DialogResult.OK)
                         {
                             EditFilePooling efp = new EditFilePooling(openFileDialog1.FileName);
-                            efp.ShowDialog();
+                            efp.ShowDialog(this);
                             await OpenFilePooling(title, offlineAnalogy.InitialFolderFullPath, efp.Filter, openFileDialog1.FileName);
                             AddRecentFiles(recentfiles, offlineAnalogy, title,
                                 new List<string> { openFileDialog1.FileName });

--- a/Analogy/Forms/FluentDesignMainForm.cs
+++ b/Analogy/Forms/FluentDesignMainForm.cs
@@ -848,11 +848,11 @@ namespace Analogy
                     dockManager1.ActivePanel = page;
                 }
 
-                async Task OpenFilePooling(string titleOfDataSource, string initialFolder, string file)
+                async Task OpenFilePooling(string titleOfDataSource, string initialFolder, string file, string  initialFile)
                 {
                     openedWindows++;
                     await FactoriesManager.Instance.InitializeIfNeeded(offlineAnalogy);
-                    UserControl filepoolingUC = new FilePoolingUCLogs(offlineAnalogy, file, initialFolder);
+                    UserControl filepoolingUC = new FilePoolingUCLogs(offlineAnalogy, file, initialFile, initialFolder);
                     var page = dockManager1.AddPanel(DockingStyle.Float);
                     page.DockedAsTabbedDocument = true;
 
@@ -1006,7 +1006,9 @@ namespace Analogy
                         };
                         if (openFileDialog1.ShowDialog() == DialogResult.OK)
                         {
-                            await OpenFilePooling(title, offlineAnalogy.InitialFolderFullPath, openFileDialog1.FileName);
+                            EditFilePooling efp = new EditFilePooling(openFileDialog1.FileName);
+                            efp.ShowDialog();
+                            await OpenFilePooling(title, offlineAnalogy.InitialFolderFullPath, efp.Filter, openFileDialog1.FileName);
                             AddRecentFiles(recentfiles, offlineAnalogy, title,
                                 new List<string> { openFileDialog1.FileName });
                         }

--- a/Analogy/Forms/MainForm.cs
+++ b/Analogy/Forms/MainForm.cs
@@ -1707,7 +1707,7 @@ namespace Analogy.Forms
                         if (openFileDialog1.ShowDialog() == DialogResult.OK)
                         {
                             EditFilePooling efp = new EditFilePooling(openFileDialog1.FileName);
-                            efp.ShowDialog();
+                            efp.ShowDialog(this);
                             await OpenFilePooling(dataProvider.OptionalTitle, dataProvider,
                                 dataProvider.InitialFolderFullPath, efp.Filter, openFileDialog1.FileName);
                             AddRecentFiles(ribbonPage, recentBar, dataProvider, dataProvider.OptionalTitle,
@@ -2005,7 +2005,7 @@ namespace Analogy.Forms
                     if (openFileDialog1.ShowDialog() == DialogResult.OK)
                     {
                         EditFilePooling efp = new EditFilePooling(openFileDialog1.FileName);
-                        efp.ShowDialog();
+                        efp.ShowDialog(this);
                         OpenFilePooling(title, offlineAnalogy.InitialFolderFullPath, efp.Filter, openFileDialog1.FileName);
                         AddRecentFiles(ribbonPage, recentBar, offlineAnalogy, title,
                             new List<string> { openFileDialog1.FileName });

--- a/Analogy/Forms/MainForm.cs
+++ b/Analogy/Forms/MainForm.cs
@@ -1488,12 +1488,12 @@ namespace Analogy.Forms
             }
 
             async Task OpenFilePooling(string titleOfDataSource, IAnalogyOfflineDataProvider dataProvider,
-                string initialFolder, string file)
+                string initialFolder, string file,  string  initialFile)
             {
 
                 OpenedWindows++;
                 await FactoriesManager.Instance.InitializeIfNeeded(dataProvider);
-                UserControl filepoolingUC = new FilePoolingUCLogs(dataProvider, file, initialFolder);
+                UserControl filepoolingUC = new FilePoolingUCLogs(dataProvider, file, initialFile, initialFolder);
                 var page = dockManager1.AddPanel(DockingStyle.Float);
                 page.DockedAsTabbedDocument = true;
 
@@ -1706,8 +1706,10 @@ namespace Analogy.Forms
                         };
                         if (openFileDialog1.ShowDialog() == DialogResult.OK)
                         {
+                            EditFilePooling efp = new EditFilePooling(openFileDialog1.FileName);
+                            efp.ShowDialog();
                             await OpenFilePooling(dataProvider.OptionalTitle, dataProvider,
-                                dataProvider.InitialFolderFullPath, openFileDialog1.FileName);
+                                dataProvider.InitialFolderFullPath, efp.Filter, openFileDialog1.FileName);
                             AddRecentFiles(ribbonPage, recentBar, dataProvider, dataProvider.OptionalTitle,
                                 new List<string> { openFileDialog1.FileName });
                         }
@@ -1850,11 +1852,11 @@ namespace Analogy.Forms
 
             }
 
-            void OpenFilePooling(string titleOfDataSource, string initialFolder, string file)
+            void OpenFilePooling(string titleOfDataSource, string initialFolder, string file, string  initialFile)
             {
 
                 OpenedWindows++;
-                UserControl filepoolingUC = new FilePoolingUCLogs(offlineAnalogy, file, initialFolder);
+                UserControl filepoolingUC = new FilePoolingUCLogs(offlineAnalogy, file, initialFile, initialFolder);
                 var page = dockManager1.AddPanel(DockingStyle.Float);
                 page.DockedAsTabbedDocument = true;
 
@@ -2002,7 +2004,9 @@ namespace Analogy.Forms
                     };
                     if (openFileDialog1.ShowDialog() == DialogResult.OK)
                     {
-                        OpenFilePooling(title, offlineAnalogy.InitialFolderFullPath, openFileDialog1.FileName);
+                        EditFilePooling efp = new EditFilePooling(openFileDialog1.FileName);
+                        efp.ShowDialog();
+                        OpenFilePooling(title, offlineAnalogy.InitialFolderFullPath, efp.Filter, openFileDialog1.FileName);
                         AddRecentFiles(ribbonPage, recentBar, offlineAnalogy, title,
                             new List<string> { openFileDialog1.FileName });
                     }

--- a/Analogy/Managers/FilePoolingManager.cs
+++ b/Analogy/Managers/FilePoolingManager.cs
@@ -1,232 +1,219 @@
-﻿using Analogy.Interfaces;
-using Analogy.Interfaces.DataTypes;
-using Analogy.UserControls;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Analogy.Common.DataTypes;
-using Analogy.Common.Interfaces;
+using Analogy.Interfaces;
+using Analogy.Interfaces.DataTypes;
+using Analogy.UserControls;
 
-namespace Analogy.Managers
+namespace Analogy.Managers;
+
+internal class FilePoolingManager : ILogMessageCreatedHandler
 {
-    internal class FilePoolingManager : ILogMessageCreatedHandler
+    private readonly CancellationTokenSource _cancellationTokenSource;
+    private readonly AnalogyLogMessageCustomEqualityComparer _customEqualityComparer;
+    private readonly UCLogs _logUI;
+    private readonly List<IAnalogyLogMessage> _messages;
+
+    private readonly object _sync;
+    private DateTime _lastRead;
+    private DateTime _lastWriteTime = DateTime.MinValue;
+    private bool _readingInprogress;
+    private FileSystemWatcher _watchFile;
+    public EventHandler<(List<IAnalogyLogMessage> messages, string dataSource)> OnNewMessages;
+
+    public FilePoolingManager(string filter, string initialFilename, UCLogs logUI, IAnalogyOfflineDataProvider offlineDataProvider)
     {
-        private IAnalogyUserSettings Settings => UserSettingsManager.UserSettings;
+        _sync = new object();
+        _logUI = logUI;
+        _customEqualityComparer = new AnalogyLogMessageCustomEqualityComparer { CompareId = false };
+        _cancellationTokenSource = new CancellationTokenSource();
+        OfflineDataProvider = offlineDataProvider;
+        _messages = new List<IAnalogyLogMessage>();
+        FileName = initialFilename;
+        FileFilter = filter;
+        FileProcessor = new FileProcessor(Settings, this, AnalogyLogger.Instance);
+    }
 
-        private string FileName { get; }
-        private FileProcessor FileProcessor { get; }
-        private IAnalogyOfflineDataProvider OfflineDataProvider { get; }
-        private readonly CancellationTokenSource _cancellationTokenSource;
-        private readonly List<IAnalogyLogMessage> _messages;
-        public EventHandler<(List<IAnalogyLogMessage> messages, string dataSource)> OnNewMessages;
-        public bool ForceNoFileCaching { get; set; } = true;
+    private IAnalogyUserSettings Settings
+    {
+        get { return UserSettingsManager.UserSettings; }
+    }
 
-        public bool DoNotAddToRecentHistory { get; set; } = true;
-        private readonly object _sync;
-        private FileSystemWatcher _watchFile;
-        private bool _readingInprogress;
-        private DateTime lastWriteTime = DateTime.MinValue;
-        private DateTime lastRead;
-        private UCLogs LogUI;
-        private readonly AnalogyLogMessageCustomEqualityComparer _customEqualityComparer;
-        public FilePoolingManager(string filter,  string  initialFilename, UCLogs logUI, IAnalogyOfflineDataProvider offlineDataProvider)
+    private string FileName { get; }
+    private FileProcessor FileProcessor { get; }
+    private IAnalogyOfflineDataProvider OfflineDataProvider { get; }
+
+    public string FileFilter { get; set; }
+
+    public bool HasFiltFilter { get; set; }
+    public bool ForceNoFileCaching { get; set; } = true;
+    public bool DoNotAddToRecentHistory { get; set; } = true;
+
+    public void AppendMessage(IAnalogyLogMessage message, string dataSource)
+    {
+        lock (_sync)
         {
-            _sync = new object();
-            LogUI = logUI;
-            _customEqualityComparer = new AnalogyLogMessageCustomEqualityComparer { CompareId = false };
-            _cancellationTokenSource = new CancellationTokenSource();
-            OfflineDataProvider = offlineDataProvider;
-            _messages = new List<IAnalogyLogMessage>();
-            FileName = initialFilename;
-            FileFilter = filter;
-            FileProcessor = new FileProcessor(Settings, this,AnalogyLogger.Instance);
-
-        }
-
-        public string FileFilter { get; set; }
-
-        public Task Init()
-        {
-            HasFiltFilter = !FileFilter.Equals(FileName);
-            _watchFile = new FileSystemWatcher
+            if (!_messages.Contains(message))
             {
-                Path = Path.GetDirectoryName(FileName),
-                Filter = Path.GetFileName(FileFilter)
-            };
-            _watchFile.Changed += WatchFile_Changed;
-            if (HasFiltFilter)
-            {
-                _watchFile.Deleted += WatchFile_Deleted;
-                _watchFile.Renamed += WatchFile_Renamed;
+                _messages.Add(message);
+                OnNewMessages?.Invoke(this, (new List<IAnalogyLogMessage> { message }, dataSource));
             }
-            _watchFile.Error += WatchFile_Error;
+        }
+    }
+
+    public void AppendMessages(List<IAnalogyLogMessage> messagesFromFile, string dataSource)
+    {
+        lock (_sync)
+        {
+            List<IAnalogyLogMessage> newMessages = messagesFromFile.Except(_messages, _customEqualityComparer).ToList();
+            if (newMessages.Any())
+            {
+                _messages.AddRange(newMessages);
+                OnNewMessages?.Invoke(this, (newMessages, dataSource));
+            }
+        }
+    }
+
+    public void ReportFileReadProgress(AnalogyFileReadProgress progress)
+    {
+        //noop
+    }
+
+    public Task Init()
+    {
+        HasFiltFilter = !FileFilter.Equals(FileName);
+        _watchFile = new FileSystemWatcher
+                     {
+                         Path = Path.GetDirectoryName(FileName),
+                         Filter = Path.GetFileName(FileFilter)
+                     };
+        _watchFile.Changed += WatchFile_Changed;
+        if (!HasFiltFilter)
+        {
+            _watchFile.Deleted += WatchFile_Deleted;
+            _watchFile.Renamed += WatchFile_Renamed;
+        }
+        _watchFile.Error += WatchFile_Error;
+        _watchFile.EnableRaisingEvents = true;
+        AnalogyLogMessage m = new()
+                              {
+                                  Text = $"Start monitoring file {FileFilter}.",
+                                  FileName = FileFilter,
+                                  Level = AnalogyLogLevel.Analogy,
+                                  Source = "Analogy",
+                                  Class = AnalogyLogClass.General,
+                                  Date = DateTime.Now
+                              };
+        OnNewMessages?.Invoke(this, (new List<IAnalogyLogMessage> { m }, FileName));
+        return FileProcessor.Process(OfflineDataProvider, FileName, _cancellationTokenSource.Token);
+    }
+
+    public void StopMonitoring()
+    {
+        _watchFile.EnableRaisingEvents = false;
+        _watchFile.Changed -= WatchFile_Changed;
+        if (!HasFiltFilter)
+        {
+            _watchFile.Deleted -= WatchFile_Deleted;
+            _watchFile.Renamed -= WatchFile_Renamed;
+        }
+        _watchFile.Error -= WatchFile_Error;
+        _watchFile.Dispose();
+    }
+
+    private void WatchFile_Error(object sender, ErrorEventArgs e)
+    {
+        _watchFile.EnableRaisingEvents = false;
+        _watchFile.Dispose();
+        AnalogyLogMessage m = new()
+                              {
+                                  Text = $"Error monitoring file {FileName}. Reason {e.GetException()}",
+                                  FileName = FileName,
+                                  Level = AnalogyLogLevel.Critical,
+                                  Source = "Analogy",
+                                  Class = AnalogyLogClass.General,
+                                  Date = DateTime.Now
+                              };
+        OnNewMessages?.Invoke(this, (new List<IAnalogyLogMessage> { m }, FileName));
+    }
+
+    private async void WatchFile_Renamed(object sender, RenamedEventArgs e)
+    {
+        _watchFile.EnableRaisingEvents = false;
+        AnalogyLogMessage m = new()
+                              {
+                                  Text = $"{FileName} has changed to {e.FullPath} from {e.OldName}. restarting monitoring",
+                                  FileName = FileName,
+                                  Level = AnalogyLogLevel.Warning,
+                                  Source = "Analogy",
+                                  Class = AnalogyLogClass.General,
+                                  Date = DateTime.Now
+                              };
+        _watchFile.Dispose();
+        OnNewMessages?.Invoke(this, (new List<IAnalogyLogMessage> { m }, FileName));
+        await Init();
+    }
+
+    private void WatchFile_Deleted(object sender, FileSystemEventArgs e)
+    {
+        _watchFile.EnableRaisingEvents = false;
+        AnalogyLogMessage m = new()
+                              {
+                                  Text = $"{FileName} has been deleted. Stopping monitoring",
+                                  FileName = FileName,
+                                  Level = AnalogyLogLevel.Warning,
+                                  Class = AnalogyLogClass.General,
+                                  Date = DateTime.Now
+                              };
+        _watchFile.Dispose();
+        OnNewMessages?.Invoke(this, (new List<IAnalogyLogMessage> { m }, FileName));
+    }
+
+    private async void WatchFile_Changed(object sender, FileSystemEventArgs e)
+    {
+        if (_readingInprogress)
+            return;
+        FileInfo f = new(e.FullPath);
+        if (_lastWriteTime == f.LastWriteTime)
+            return;
+        lock (_sync)
+        {
+            if (_readingInprogress || (Settings.EnableFilePoolingDelay && DateTime.Now.Subtract(_lastRead).TotalSeconds <= Settings.FilePoolingDelayInterval))
+                return;
+            _lastWriteTime = f.LastWriteTime;
+            _lastRead = DateTime.Now;
+            _watchFile.EnableRaisingEvents = false;
+            _readingInprogress = true;
+        }
+        try
+        {
+            if (e.ChangeType == WatcherChangeTypes.Changed)
+            {
+                _logUI.SetReloadColorDate(FileProcessor.lastNewestMessage);
+                await FileProcessor.Process(OfflineDataProvider, e.FullPath, _cancellationTokenSource.Token);
+            }
+        }
+        catch (Exception exception)
+        {
+            AnalogyLogMessage m = new()
+                                  {
+                                      Text = $"Error monitoring file {e.FullPath}. Reason {exception}",
+                                      FileName = FileName,
+                                      Level = AnalogyLogLevel.Warning,
+                                      Class = AnalogyLogClass.General,
+                                      Date = DateTime.Now
+                                  };
+            OnNewMessages?.Invoke(this, (new List<IAnalogyLogMessage> { m }, e.FullPath));
+            AnalogyLogManager.Instance.LogErrorMessage(m);
+        }
+        finally
+        {
+            _readingInprogress = false;
             _watchFile.EnableRaisingEvents = true;
-            AnalogyLogMessage m = new AnalogyLogMessage
-            {
-                Text = $"Start monitoring file {FileFilter}.",
-                FileName = FileFilter,
-                Level = AnalogyLogLevel.Analogy,
-                Source = "Analogy",
-                Class = AnalogyLogClass.General,
-                Date = DateTime.Now
-            };
-            
-            OnNewMessages?.Invoke(this, (new List<IAnalogyLogMessage> { m }, FileName));
-            return FileProcessor.Process(OfflineDataProvider, FileName, _cancellationTokenSource.Token);
-        }
-
-        public bool HasFiltFilter { get; set; }
-
-        public void StopMonitoring()
-        {
-
-            _watchFile.EnableRaisingEvents = false;
-            _watchFile.Changed -= WatchFile_Changed;
-            if (HasFiltFilter)
-            {
-                _watchFile.Deleted -= WatchFile_Deleted;
-                _watchFile.Renamed -= WatchFile_Renamed;
-            }
-            _watchFile.Error -= WatchFile_Error;
-            _watchFile.Dispose();
-        }
-        public void AppendMessage(IAnalogyLogMessage message, string dataSource)
-        {
-            lock (_sync)
-            {
-                if (!_messages.Contains(message))
-                {
-                    _messages.Add(message);
-                    OnNewMessages?.Invoke(this, (new List<IAnalogyLogMessage> { message }, dataSource));
-                }
-            }
-        }
-
-        public void AppendMessages(List<IAnalogyLogMessage> messagesFromFile, string dataSource)
-        {
-
-            lock (_sync)
-            {
-                var newMessages = messagesFromFile.Except(_messages, _customEqualityComparer).ToList();
-                if (newMessages.Any())
-                {
-                    _messages.AddRange(newMessages);
-                    OnNewMessages?.Invoke(this, (newMessages, dataSource));
-                }
-            }
-        }
-
-        private void WatchFile_Error(object sender, ErrorEventArgs e)
-        {
-            _watchFile.EnableRaisingEvents = false;
-            _watchFile.Dispose();
-            AnalogyLogMessage m = new AnalogyLogMessage
-            {
-                Text = $"Error monitoring file {FileName}. Reason {e.GetException()}",
-                FileName = FileName,
-                Level = AnalogyLogLevel.Critical,
-                Source = "Analogy",
-                Class = AnalogyLogClass.General,
-                Date = DateTime.Now
-            };
-            OnNewMessages?.Invoke(this, (new List<IAnalogyLogMessage> { m }, FileName));
-        }
-
-        private async void WatchFile_Renamed(object sender, RenamedEventArgs e)
-        {
-            _watchFile.EnableRaisingEvents = false;
-            AnalogyLogMessage m = new AnalogyLogMessage
-            {
-                Text = $"{FileName} has changed to {e.FullPath} from {e.OldName}. restarting monitoring",
-                FileName = FileName,
-                Level = AnalogyLogLevel.Warning,
-                Source = "Analogy",
-                Class = AnalogyLogClass.General,
-                Date = DateTime.Now
-            };
-            _watchFile.Dispose();
-            OnNewMessages?.Invoke(this, (new List<IAnalogyLogMessage> { m }, FileName));
-            await Init();
-
-        }
-
-        private void WatchFile_Deleted(object sender, FileSystemEventArgs e)
-        {
-            _watchFile.EnableRaisingEvents = false;
-            AnalogyLogMessage m = new AnalogyLogMessage
-            {
-                Text = $"{FileName} has been deleted. Stopping monitoring",
-                FileName = FileName,
-                Level = AnalogyLogLevel.Warning,
-                Class = AnalogyLogClass.General,
-                Date = DateTime.Now
-            };
-            _watchFile.Dispose();
-            OnNewMessages?.Invoke(this, (new List<IAnalogyLogMessage> { m }, FileName));
-        }
-
-        private async void WatchFile_Changed(object sender, FileSystemEventArgs e)
-        {
-            if (_readingInprogress)
-            {
-                return;
-            }
-
-            FileInfo f = new FileInfo(e.FullPath);
-            if (lastWriteTime == f.LastWriteTime)
-            {
-                return;
-            }
-
-
-
-            lock (_sync)
-            {
-                if (_readingInprogress || (Settings.EnableFilePoolingDelay && DateTime.Now.Subtract(lastRead).TotalSeconds <= Settings.FilePoolingDelayInterval))
-                {
-                    return;
-                }
-                lastWriteTime = f.LastWriteTime;
-                lastRead = DateTime.Now;
-                _watchFile.EnableRaisingEvents = false;
-                _readingInprogress = true;
-
-            }
-
-            try
-            {
-                if (e.ChangeType == WatcherChangeTypes.Changed)
-                {
-                    LogUI.SetReloadColorDate(FileProcessor.lastNewestMessage);
-                    await FileProcessor.Process(OfflineDataProvider, e.FullPath, _cancellationTokenSource.Token);
-                }
-            }
-            catch (Exception exception)
-            {
-                AnalogyLogMessage m = new AnalogyLogMessage
-                {
-                    Text = $"Error monitoring file {e.FullPath}. Reason {exception}",
-                    FileName = FileName,
-                    Level = AnalogyLogLevel.Warning,
-                    Class = AnalogyLogClass.General,
-                    Date = DateTime.Now
-                };
-                OnNewMessages?.Invoke(this, (new List<IAnalogyLogMessage> { m }, e.FullPath));
-                AnalogyLogManager.Instance.LogErrorMessage(m);
-            }
-            finally
-            {
-                _readingInprogress = false;
-                _watchFile.EnableRaisingEvents = true;
-            }
-        }
-        public void ReportFileReadProgress(AnalogyFileReadProgress progress)
-        {
-            //noop
         }
     }
 }
-

--- a/Analogy/Managers/FilePoolingManager.cs
+++ b/Analogy/Managers/FilePoolingManager.cs
@@ -18,7 +18,7 @@ internal class FilePoolingManager : ILogMessageCreatedHandler
     private readonly UCLogs _logUI;
     private readonly List<IAnalogyLogMessage> _messages;
     //Instantiate a Singleton of the Semaphore with a value of 1. This means that only 1 thread can be granted access at a time.
-    static SemaphoreSlim _watcherSemaphore = new SemaphoreSlim(1,1);
+    private readonly SemaphoreSlim _watcherSemaphore = new(1,1);
 
     private readonly object _sync;
     private DateTime _lastRead;

--- a/Analogy/Properties/licenses.licx
+++ b/Analogy/Properties/licenses.licx
@@ -1,2 +1,3 @@
 DevExpress.XtraBars.BarManager, DevExpress.XtraBars.v21.2, Version=21.2.12.0, Culture=neutral, PublicKeyToken=b88d1754d700e49a
+DevExpress.XtraEditors.TextEdit, DevExpress.XtraEditors.v21.2, Version=21.2.12.0, Culture=neutral, PublicKeyToken=b88d1754d700e49a
 DevExpress.XtraEditors.CheckEdit, DevExpress.XtraEditors.v21.2, Version=21.2.12.0, Culture=neutral, PublicKeyToken=b88d1754d700e49a

--- a/Analogy/UserControls/FilePoolingLog.cs
+++ b/Analogy/UserControls/FilePoolingLog.cs
@@ -22,11 +22,11 @@ namespace Analogy
         private string FileName { get; set; }
         public bool Enable { get; set; } = true;
         private FilePoolingManager PoolingManager { get; }
-        public FilePoolingUCLogs(IAnalogyOfflineDataProvider offlineDataProvider, string fileName, string initialFolder)
+        public FilePoolingUCLogs(IAnalogyOfflineDataProvider offlineDataProvider, string filter,  string  initialFilename, string initialFolder)
         {
             InitializeComponent();
-            FileName = fileName;
-            PoolingManager = new FilePoolingManager(FileName, ucLogs1, offlineDataProvider);
+            FileName = initialFilename;
+            PoolingManager = new FilePoolingManager(filter, initialFilename, ucLogs1, offlineDataProvider);
             ucLogs1.SetFileDataSource(offlineDataProvider, offlineDataProvider);
             ucLogs1.EnableFileReload(FileName);
 

--- a/Dependencies.txt
+++ b/Dependencies.txt
@@ -8,7 +8,7 @@ Interface -- LogServer.Client -- NLog.Targets
 Interface -- LogServer.Client -- Serilog.Sink
 Interface -- LogServer.Client -- AspNetCore.LogProvider
 
-Interface -- LogServer.Client --         -- Grpc
+Interface -- LogServer.Client --                   -- Grpc
 Interface -- CommonUtilities -- Template -- Grpc
 
 Interface -- CommonUtilities -- Template -- RegexParser
@@ -23,7 +23,6 @@ Interface -- CommonUtilities -- Template -- Kafka
 Interface -- CommonUtilities -- Template -- Log4jXml
 Interface -- CommonUtilities -- Template -- Log4Net
 Interface -- CommonUtilities -- Template -- NLog
-Interface -- CommonUtilities -- Template -- RabbitMq
 Interface -- CommonUtilities -- Template -- Serilog 
 Interface -- CommonUtilities -- Template -- WindowsEventLogs
 Interface -- CommonUtilities -- Template -- XMLParser


### PR DESCRIPTION
Adding a simple popup when opening a file for pooling, to allow to have a custom filter pattern, in order to support rolling files scheme.

![image](https://user-images.githubusercontent.com/13061922/228465551-b7cc6cc4-890b-44f0-a610-c323df2af159.png)

The FileSystemWatcher will then use this filter to watches the corresponding files (and only them). The popup allow a simple way for the user to change the filter, without needing to change each data provider implementation.

Also added a semaphore to correct a bug on closing file pooling tabs.

DevExpress skin wasn't applied.