### PR TITLE
Improving docking UX and other improvements

### DIFF
--- a/Analogy.CommonControls/UserControls/LogMessagesUC.Designer.cs
+++ b/Analogy.CommonControls/UserControls/LogMessagesUC.Designer.cs
@@ -282,9 +282,11 @@ namespace Analogy.CommonControls.UserControls
             this.dockManager1 = new DevExpress.XtraBars.Docking.DockManager(this.components);
             this.dockPanelLogs = new DevExpress.XtraBars.Docking.DockPanel();
             this.dockPanel2_Container = new DevExpress.XtraBars.Docking.ControlContainer();
-            this.panelContainer1 = new DevExpress.XtraBars.Docking.DockPanel();
+            this.dockPanelDetails = new DevExpress.XtraBars.Docking.DockPanel();
+            this.dockPanelTree = new DevExpress.XtraBars.Docking.DockPanel();
             this.dockPanelMessageInfo = new DevExpress.XtraBars.Docking.DockPanel();
             this.controlContainer1 = new DevExpress.XtraBars.Docking.ControlContainer();
+            this.dockPanelTreeContainer = new DevExpress.XtraBars.Docking.ControlContainer();
             this.scMessageDetails = new DevExpress.XtraEditors.SplitContainerControl();
             this.meMessageDetails = new DevExpress.XtraEditors.MemoEdit();
             this.recMessageDetails = new DevExpress.XtraRichEdit.RichEditControl();
@@ -391,9 +393,11 @@ namespace Analogy.CommonControls.UserControls
             ((System.ComponentModel.ISupportInitialize)(this.dockManager1)).BeginInit();
             this.dockPanelLogs.SuspendLayout();
             this.dockPanel2_Container.SuspendLayout();
-            this.panelContainer1.SuspendLayout();
+            this.dockPanelDetails.SuspendLayout();
+            this.dockPanelTree.SuspendLayout();
             this.dockPanelMessageInfo.SuspendLayout();
             this.controlContainer1.SuspendLayout();
+            this.dockPanelTreeContainer.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.scMessageDetails)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.scMessageDetails.Panel1)).BeginInit();
             this.scMessageDetails.Panel1.SuspendLayout();
@@ -3029,8 +3033,10 @@ namespace Analogy.CommonControls.UserControls
             this.dockManager1.Form = this;
             this.dockManager1.RootPanels.AddRange(new DevExpress.XtraBars.Docking.DockPanel[] {
             this.dockPanelLogs,
-            this.panelContainer1,
-            this.dockPanelFiltering});
+            this.dockPanelDetails,
+            this.dockPanelFiltering,
+            this.dockPanelTree
+        });
             this.dockManager1.TopZIndexControls.AddRange(new string[] {
             "DevExpress.XtraBars.BarDockControl",
             "DevExpress.XtraBars.StandaloneBarDockControl",
@@ -3064,20 +3070,40 @@ namespace Analogy.CommonControls.UserControls
             this.dockPanel2_Container.Size = new System.Drawing.Size(1847, 248);
             this.dockPanel2_Container.TabIndex = 0;
             // 
-            // panelContainer1
+            // dockPanelDetails
             // 
-            this.panelContainer1.ActiveChild = this.dockPanelMessageInfo;
-            this.panelContainer1.Controls.Add(this.dockPanelMessageInfo);
-            this.panelContainer1.Controls.Add(this.dockPanelBookmarks);
-            this.panelContainer1.Dock = DevExpress.XtraBars.Docking.DockingStyle.Bottom;
-            this.panelContainer1.FloatSize = new System.Drawing.Size(428, 200);
-            this.panelContainer1.ID = new System.Guid("ac1a6167-81e4-42f6-b999-c394cc58516b");
-            this.panelContainer1.Location = new System.Drawing.Point(0, 523);
-            this.panelContainer1.Name = "panelContainer1";
-            this.panelContainer1.OriginalSize = new System.Drawing.Size(200, 204);
-            this.panelContainer1.Size = new System.Drawing.Size(1853, 204);
-            this.panelContainer1.Tabbed = true;
-            this.panelContainer1.Text = "panelContainer1";
+            this.dockPanelDetails.ActiveChild = this.dockPanelMessageInfo;
+            this.dockPanelDetails.Controls.Add(this.dockPanelMessageInfo);
+            this.dockPanelDetails.Controls.Add(this.dockPanelBookmarks);
+            this.dockPanelDetails.Dock = DevExpress.XtraBars.Docking.DockingStyle.Bottom;
+            this.dockPanelDetails.FloatSize = new System.Drawing.Size(428, 200);
+            this.dockPanelDetails.ID = new System.Guid("ac1a6167-81e4-42f6-b999-c394cc58516b");
+            this.dockPanelDetails.Location = new System.Drawing.Point(0, 523);
+            this.dockPanelDetails.Name = "dockPanelDetails";
+            this.dockPanelDetails.OriginalSize = new System.Drawing.Size(200, 204);
+            this.dockPanelDetails.Size = new System.Drawing.Size(1853, 204);
+            this.dockPanelDetails.Tabbed = true;
+            this.dockPanelDetails.Text = "dockPanelDetails";
+            // 
+            // dockPanelTree
+            // 
+            this.dockPanelTree.Controls.Add(this.dockPanelTreeContainer);
+            this.dockPanelTree.Dock = DevExpress.XtraBars.Docking.DockingStyle.Right;
+            this.dockPanelTree.FloatSize = new System.Drawing.Size(500, 800);
+            this.dockPanelTree.ID = new System.Guid("B1CBEA9D-31D1-466D-AC5F-9854CB01FD71");
+            this.dockPanelTree.Location = new System.Drawing.Point(0, 0);
+            this.dockPanelTree.Name = "dockPanelTree";
+            this.dockPanelTree.OriginalSize = new System.Drawing.Size(200, 204);
+            this.dockPanelTree.Size = new System.Drawing.Size(400, 800);
+            this.dockPanelTree.Options.ShowCloseButton = true;
+            this.dockPanelTree.Text = "dockPanelTree";
+            // 
+            // controlContainer1
+            // 
+            this.dockPanelTreeContainer.Location = new System.Drawing.Point(0, 0);
+            this.dockPanelTreeContainer.Name = "dockPanelTreeContainer";
+            this.dockPanelTreeContainer.Size = new System.Drawing.Size(400, 800);
+            this.dockPanelTreeContainer.TabIndex = 0;
             // 
             // dockPanelMessageInfo
             // 
@@ -3285,7 +3311,8 @@ namespace Analogy.CommonControls.UserControls
             this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.dockPanelFiltering);
-            this.Controls.Add(this.panelContainer1);
+            this.Controls.Add(this.dockPanelDetails);
+            this.Controls.Add(this.dockPanelTree);
             this.Controls.Add(this.barDockControlLeft);
             this.Controls.Add(this.barDockControlRight);
             this.Controls.Add(this.barDockControlBottom);
@@ -3386,10 +3413,13 @@ namespace Analogy.CommonControls.UserControls
             this.dockPanelLogs.ResumeLayout(false);
             this.dockPanel2_Container.ResumeLayout(false);
             this.dockPanel2_Container.PerformLayout();
-            this.panelContainer1.ResumeLayout(false);
+            this.dockPanelDetails.ResumeLayout(false);
+            this.dockPanelTree.ResumeLayout(false);
             this.dockPanelMessageInfo.ResumeLayout(false);
             this.controlContainer1.ResumeLayout(false);
             this.controlContainer1.PerformLayout();
+            this.dockPanelTreeContainer.ResumeLayout(false);
+            this.dockPanelTreeContainer.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.scMessageDetails.Panel1)).EndInit();
             this.scMessageDetails.Panel1.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.scMessageDetails.Panel2)).EndInit();
@@ -3570,8 +3600,10 @@ namespace Analogy.CommonControls.UserControls
         private DevExpress.XtraEditors.Repository.RepositoryItemProgressBar repositoryItemProgressBar2;
         private DevExpress.XtraBars.Docking.DockPanel dockPanelMessageInfo;
         private DevExpress.XtraBars.Docking.ControlContainer controlContainer1;
+        private DevExpress.XtraBars.Docking.ControlContainer dockPanelTreeContainer;
         private DevExpress.XtraBars.StandaloneBarDockControl sbarMessageInfo;
-        private DevExpress.XtraBars.Docking.DockPanel panelContainer1;
+        private DevExpress.XtraBars.Docking.DockPanel dockPanelDetails;
+        private DevExpress.XtraBars.Docking.DockPanel dockPanelTree;
         private DevExpress.XtraBars.StandaloneBarDockControl sbarBookmarks;
         private DevExpress.XtraEditors.PanelControl pnlLevel;
         private DevExpress.XtraEditors.PanelControl pnlLevelFilteringType;

--- a/Analogy.CommonControls/UserControls/LogMessagesUC.cs
+++ b/Analogy.CommonControls/UserControls/LogMessagesUC.cs
@@ -1458,12 +1458,12 @@ namespace Analogy.CommonControls.UserControls
                 DockPanel? pnl = dockManager1.Panels.FirstOrDefault(i => i.ID == extension.Id);
                 if (pnl == null)
                 {
-                    pnl = dockManager1.AddPanel(DockingStyle.Float);
+                    pnl = dockPanelTree;
                     pnl.Text = extension.Title;
                     pnl.ID = extension.Id;
-                    pnl.DockedAsTabbedDocument = true;
                 }
-                pnl.Controls.Add(extension.CreateUserControl(Id, Logger));
+                //pnl.Controls.Add(extension.CreateUserControl(Id, Logger));
+                pnl.ControlContainer.Controls.Add(extension.CreateUserControl(Id, Logger));
                 pnl.SizeChanged += ExtensionPanel_SizeChanged;
                 await extension.InitializeUserControl(this, Id, Logger);
             }

--- a/Analogy.CommonControls/UserControls/LogMessagesUC.cs
+++ b/Analogy.CommonControls/UserControls/LogMessagesUC.cs
@@ -399,7 +399,8 @@ namespace Analogy.CommonControls.UserControls
             documentManager1.BeginUpdate();
             documentManager1.View.ActivateDocument(dockPanelLogs);
             documentManager1.EndUpdate();
-
+            LogGrid.ClearSorting();  
+            LogGrid.Columns[DataGridDateColumnName].SortOrder = ColumnSortOrder.Ascending;
         }
 
         private void HideColumns()

--- a/Analogy.CommonControls/UserControls/LogMessagesUC.cs
+++ b/Analogy.CommonControls/UserControls/LogMessagesUC.cs
@@ -31,6 +31,7 @@ using DevExpress.Utils.Menu;
 using DevExpress.XtraBars;
 using DevExpress.XtraBars.Alerter;
 using DevExpress.XtraBars.Docking;
+using DevExpress.XtraCharts;
 using DevExpress.XtraEditors;
 using DevExpress.XtraEditors.Controls;
 using DevExpress.XtraEditors.Mask;
@@ -183,6 +184,8 @@ namespace Analogy.CommonControls.UserControls
             }
         }
         private LogLevelSelectionType LogLevelSelectionType => Settings.LogLevelSelection;
+        public string? Title { get; set; }
+
         #endregion
 
         #region fields
@@ -1462,7 +1465,8 @@ namespace Analogy.CommonControls.UserControls
                     pnl.Text = extension.Title;
                     pnl.ID = extension.Id;
                 }
-                //pnl.Controls.Add(extension.CreateUserControl(Id, Logger));
+                if (Title != null && pnl.ParentPanel != null)
+                    pnl.ParentPanel.Text = Title;
                 pnl.ControlContainer.Controls.Add(extension.CreateUserControl(Id, Logger));
                 pnl.SizeChanged += ExtensionPanel_SizeChanged;
                 await extension.InitializeUserControl(this, Id, Logger);

--- a/Analogy.CommonControls/UserControls/LogMessagesUC.cs
+++ b/Analogy.CommonControls/UserControls/LogMessagesUC.cs
@@ -3659,6 +3659,24 @@ namespace Analogy.CommonControls.UserControls
         {
             DataProviderProgressReporter.Report(progress);
         }
+
+        
+
+        public void ShowSecondaryWindow()
+        {
+            foreach (DockPanel dockPanel in dockManager1.Panels.Where(i => i.Dock == DockingStyle.Float).ToList())
+            {
+                dockPanel.Visibility = DockVisibility.Visible;
+            }
+        }
+
+        public void HideSecondaryWindow()
+        {
+            foreach (DockPanel dockPanel in dockManager1.Panels.Where(i => i.Dock == DockingStyle.Float).ToList())
+            {
+                dockPanel.Visibility = DockVisibility.Hidden;
+            }
+        }
     }
 }
 

--- a/Analogy/Analogy.csproj
+++ b/Analogy/Analogy.csproj
@@ -49,6 +49,7 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Analogy.LogViewer.Interfaces" Version="3.8.3" />
+		<PackageReference Include="Analogy.LogViewer.LoggersTree" Version="1.0.2" />
 		<PackageReference Include="Analogy.LogViewer.Template" Version="3.8.3" />
 		<PackageReference Include="Analogy.CommonUtilities" Version="3.8.3" />
 		<PackageReference Include="Analogy.LogViewer.XMLParser" Version="3.8.3" />
@@ -790,7 +791,6 @@
 		<Folder Include="Updater\" />
 	</ItemGroup>
 	<ItemGroup>
-		<ProjectReference Include="..\..\Analogy.LogViewer.LoggersTree\Analogy.LogViewer.LoggersTree\Analogy.LogViewer.LoggersTree.csproj" />
 		<ProjectReference Include="..\Analogy.CommonControls\Analogy.CommonControls.csproj" />
 		<ProjectReference Include="..\Analogy.Common\Analogy.Common.csproj" />
 	</ItemGroup>

--- a/Analogy/Analogy.csproj
+++ b/Analogy/Analogy.csproj
@@ -49,7 +49,6 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Analogy.LogViewer.Interfaces" Version="3.8.3" />
-		<PackageReference Include="Analogy.LogViewer.LoggersTree" Version="1.0.2" />
 		<PackageReference Include="Analogy.LogViewer.Template" Version="3.8.3" />
 		<PackageReference Include="Analogy.CommonUtilities" Version="3.8.3" />
 		<PackageReference Include="Analogy.LogViewer.XMLParser" Version="3.8.3" />
@@ -791,6 +790,7 @@
 		<Folder Include="Updater\" />
 	</ItemGroup>
 	<ItemGroup>
+		<ProjectReference Include="..\..\Analogy.LogViewer.LoggersTree\Analogy.LogViewer.LoggersTree\Analogy.LogViewer.LoggersTree.csproj" />
 		<ProjectReference Include="..\Analogy.CommonControls\Analogy.CommonControls.csproj" />
 		<ProjectReference Include="..\Analogy.Common\Analogy.Common.csproj" />
 	</ItemGroup>

--- a/Analogy/Forms/FluentDesignMainForm.cs
+++ b/Analogy/Forms/FluentDesignMainForm.cs
@@ -339,12 +339,13 @@ namespace Analogy
         {
             openedWindows++;
             await FactoriesManager.Instance.InitializeIfNeeded(dataProvider);
-            UserControl offlineUC = new LocalLogFilesUC(dataProvider, fileNames);
+            string fullTitle =  $"{offlineTitle} #{openedWindows}{(title == null ? "" : $" ({title})")}";
+            UserControl offlineUC = new LocalLogFilesUC(dataProvider, fileNames, title: fullTitle);
             var page = dockManager1.AddPanel(DockingStyle.Float);
             page.DockedAsTabbedDocument = true;
             page.Controls.Add(offlineUC);
             offlineUC.Dock = DockStyle.Fill;
-            page.Text = $"{offlineTitle} #{openedWindows}{(title == null ? "" : $" ({title})")}";
+            page.Text = fullTitle;
             dockManager1.ActivePanel = page;
         }
         private void SetupEventHandlers()
@@ -826,12 +827,13 @@ namespace Analogy
                 {
                     openedWindows++;
                     await FactoriesManager.Instance.InitializeIfNeeded(offlineAnalogy);
-                    UserControl offlineUC = new LocalLogFilesUC(offlineAnalogy, files, initialFolder);
+                    string fullTitle =   $"{offlineTitle} #{openedWindows} ({titleOfDataSource})";
+                    UserControl offlineUC = new LocalLogFilesUC(offlineAnalogy, files, initialFolder, title: fullTitle);
                     var page = dockManager1.AddPanel(DockingStyle.Float);
                     page.DockedAsTabbedDocument = true;
                     page.Controls.Add(offlineUC);
                     offlineUC.Dock = DockStyle.Fill;
-                    page.Text = $"{offlineTitle} #{openedWindows} ({titleOfDataSource})";
+                    page.Text = fullTitle;
                     dockManager1.ActivePanel = page;
                 }
 
@@ -1105,12 +1107,13 @@ namespace Analogy
             btn.Click += (s, be) =>
             {
                 openedWindows++;
-                UserControl offlineUC = new LocalLogFilesUC(offlineAnalogy, null, recentPath);
+                string fullTitle =  $"{offlineTitle} #{openedWindows} ({title})";
+                UserControl offlineUC = new LocalLogFilesUC(offlineAnalogy, null, recentPath, title: fullTitle);
                 var page = dockManager1.AddPanel(DockingStyle.Float);
                 page.DockedAsTabbedDocument = true;
                 page.Controls.Add(offlineUC);
                 offlineUC.Dock = DockStyle.Fill;
-                page.Text = $"{offlineTitle} #{openedWindows} ({title})";
+                page.Text = fullTitle;
                 dockManager1.ActivePanel = page;
             };
 

--- a/Analogy/Forms/MainForm.Designer.cs
+++ b/Analogy/Forms/MainForm.Designer.cs
@@ -1062,6 +1062,9 @@
             this.documentManager1.View = this.tabbedView1;
             this.documentManager1.ViewCollection.AddRange(new DevExpress.XtraBars.Docking2010.Views.BaseView[] {
             this.tabbedView1});
+
+            this.tabbedView1.DocumentActivated += TabbedView1_DocumentActivated;
+            this.tabbedView1.DocumentDeactivated += TabbedView1_DocumentDeactivated;
             // 
             // notifyIconAnalogy
             // 
@@ -1107,6 +1110,8 @@
             this.PerformLayout();
 
         }
+
+       
 
         #endregion
         private System.Windows.Forms.ImageList imageList1;

--- a/Analogy/Forms/MainForm.cs
+++ b/Analogy/Forms/MainForm.cs
@@ -1853,7 +1853,8 @@ namespace Analogy.Forms
             {
 
                 OpenedWindows++;
-                UserControl filepoolingUC = new FilePoolingUCLogs(offlineAnalogy, file, initialFile, initialFolder);
+                string fullTitle =  $"{filePoolingTitle} #{filePooling++} ({titleOfDataSource})";
+                UserControl filepoolingUC = new FilePoolingUCLogs(offlineAnalogy, file, initialFile, initialFolder, title: fullTitle);
                 var page = dockManager1.AddPanel(DockingStyle.Float);
                 page.DockedAsTabbedDocument = true;
 
@@ -1879,7 +1880,7 @@ namespace Analogy.Forms
                 page.Tag = ribbonPage;
                 page.Controls.Add(filepoolingUC);
                 filepoolingUC.Dock = DockStyle.Fill;
-                page.Text = $"{filePoolingTitle} #{filePooling++} ({titleOfDataSource})";
+                page.Text = fullTitle;
                 dockManager1.ActivePanel = page;
                 dockManager1.ClosedPanel += OnXtcLogsOnControlRemoved;
             }

--- a/Analogy/Forms/MainForm.cs
+++ b/Analogy/Forms/MainForm.cs
@@ -2344,6 +2344,22 @@ namespace Analogy.Forms
             AnalogyAboutBox ab = new AnalogyAboutBox(2);
             ab.ShowDialog(this);
         }
+
+        private void TabbedView1_DocumentDeactivated(object sender, DevExpress.XtraBars.Docking2010.Views.DocumentEventArgs e)
+        {
+            if (e.Document is { Control: DockPanel { Controls.Count: > 0 } pnl })
+                if (pnl.Controls[0] is ControlContainer { Controls.Count: > 0 } cc)
+                    if (cc.Controls[0] is IUserControlWithUCLogs logUc)
+                        logUc.HideSecondaryWindow();
+        }
+
+        private void TabbedView1_DocumentActivated(object sender, DevExpress.XtraBars.Docking2010.Views.DocumentEventArgs e)
+        {
+            if (e.Document is { Control: DockPanel { Controls.Count: > 0 } pnl })
+                if (pnl.Controls[0] is ControlContainer { Controls.Count: > 0 } cc)
+                    if (cc.Controls[0] is IUserControlWithUCLogs logUc)
+                        logUc.ShowSecondaryWindow();
+        }
     }
 }
 

--- a/Analogy/Forms/MainForm.cs
+++ b/Analogy/Forms/MainForm.cs
@@ -575,13 +575,14 @@ namespace Analogy.Forms
         {
             OpenedWindows++;
             await FactoriesManager.Instance.InitializeIfNeeded(dataProvider);
-            UserControl offlineUC = new LocalLogFilesUC(dataProvider, filenames);
+            string fullTitle =  $"{offlineTitle} #{OpenedWindows}{(title == null ? "" : $" ({title})")}";
+            UserControl offlineUC = new LocalLogFilesUC(dataProvider, filenames, title: fullTitle);
             var page = dockManager1.AddPanel(DockingStyle.Float);
             page.DockedAsTabbedDocument = true;
             page.Tag = ribbonPage;
             page.Controls.Add(offlineUC);
             offlineUC.Dock = DockStyle.Fill;
-            page.Text = $"{offlineTitle} #{OpenedWindows}{(title == null ? "" : $" ({title})")}";
+            page.Text = fullTitle;
             dockManager1.ActivePanel = page;
         }
         private void LoadStartupExtensions()
@@ -1457,13 +1458,14 @@ namespace Analogy.Forms
             {
                 OpenedWindows++;
                 await FactoriesManager.Instance.InitializeIfNeeded(dataProvider);
-                UserControl offlineUC = new LocalLogFilesUC(dataProvider, files, initialFolder);
+                string fullTitle =  $"{offlineTitle} #{OpenedWindows} ({titleOfDataSource})";
+                UserControl offlineUC = new LocalLogFilesUC(dataProvider, files, initialFolder, title: fullTitle);
                 var page = dockManager1.AddPanel(DockingStyle.Float);
                 page.DockedAsTabbedDocument = true;
                 page.Tag = ribbonPage;
                 page.Controls.Add(offlineUC);
                 offlineUC.Dock = DockStyle.Fill;
-                page.Text = $"{offlineTitle} #{OpenedWindows} ({titleOfDataSource})";
+                page.Text = fullTitle;
                 dockManager1.ActivePanel = page;
             }
 
@@ -1820,13 +1822,14 @@ namespace Analogy.Forms
             {
                 OpenedWindows++;
                 await FactoriesManager.Instance.InitializeIfNeeded(offlineAnalogy);
-                UserControl offlineUC = new LocalLogFilesUC(offlineAnalogy, files, initialFolder);
+                string fullTitle =  $"{offlineTitle} #{OpenedWindows} ({titleOfDataSource})";
+                UserControl offlineUC = new LocalLogFilesUC(offlineAnalogy, files, initialFolder, title: fullTitle);
                 var page = dockManager1.AddPanel(DockingStyle.Float);
                 page.DockedAsTabbedDocument = true;
                 page.Tag = ribbonPage;
                 page.Controls.Add(offlineUC);
                 offlineUC.Dock = DockStyle.Fill;
-                page.Text = $"{offlineTitle} #{OpenedWindows} ({titleOfDataSource})";
+                page.Text = fullTitle;
                 dockManager1.ActivePanel = page;
             }
 

--- a/Analogy/Interfaces/IUserControlWithUCLogs.cs
+++ b/Analogy/Interfaces/IUserControlWithUCLogs.cs
@@ -1,0 +1,8 @@
+﻿namespace Analogy.Interfaces
+{
+    internal interface IUserControlWithUCLogs
+    {
+        void ShowSecondaryWindow();
+        void HideSecondaryWindow();
+    }
+}

--- a/Analogy/UserControls/BookmarkLog.cs
+++ b/Analogy/UserControls/BookmarkLog.cs
@@ -1,12 +1,13 @@
 ﻿using System.Windows.Forms;
 using Analogy.CommonControls.Managers;
+using Analogy.Interfaces;
 using DevExpress.XtraBars;
 using DevExpress.XtraEditors;
 
 namespace Analogy
 {
 
-    public partial class BookmarkLog : XtraUserControl
+    public partial class BookmarkLog : XtraUserControl, IUserControlWithUCLogs
     {
         public BookmarkLog()
         {
@@ -29,6 +30,17 @@ namespace Analogy
             ucLogs1.AppendMessages(messages, "Analogy bookmarks");
             BookmarkPersistManager.Instance.MessageReceived += (s, msg) => ucLogs1.AppendMessage(msg.Message, msg.DataSource);
             BookmarkPersistManager.Instance.MessageRemoved += (s, msg) => ucLogs1.RemoveMessage(msg.Message);
+        }
+        public void ShowSecondaryWindow()
+        {
+            if (ucLogs1 != null)
+                ucLogs1.ShowSecondaryWindow();
+        }
+
+        public void HideSecondaryWindow()
+        {
+            if (ucLogs1 != null)
+                ucLogs1.HideSecondaryWindow();
         }
     }
 

--- a/Analogy/UserControls/ClientServerLog.cs
+++ b/Analogy/UserControls/ClientServerLog.cs
@@ -13,7 +13,7 @@ using Analogy.Forms;
 namespace Analogy
 {
 
-    public partial class ClientServerUCLog : XtraUserControl
+    public partial class ClientServerUCLog : XtraUserControl, IUserControlWithUCLogs
     {
         public string SelectedPath { get; set; }
         private IAnalogyOfflineDataProvider DataProvider { get; }
@@ -165,6 +165,17 @@ namespace Analogy
             }
 
             PopulateFiles(SelectedPath);
+        }
+        public void ShowSecondaryWindow()
+        {
+            if (ucLogs1 != null)
+                ucLogs1.ShowSecondaryWindow();
+        }
+
+        public void HideSecondaryWindow()
+        {
+            if (ucLogs1 != null)
+                ucLogs1.HideSecondaryWindow();
         }
     }
 

--- a/Analogy/UserControls/DataProviderUC.cs
+++ b/Analogy/UserControls/DataProviderUC.cs
@@ -11,7 +11,7 @@ using DevExpress.XtraEditors;
 
 namespace Analogy.UserControls
 {
-    public partial class DataProviderUC : XtraUserControl
+    public partial class DataProviderUC : XtraUserControl, IUserControlWithUCLogs
     {
         private IExtensionsManager ExtensionManager { get; set; } = ExtensionsManager.Instance;
         public DataProviderUC()
@@ -21,6 +21,17 @@ namespace Analogy.UserControls
 
         private void DataProviderUC_Load(object sender, EventArgs e)
         {
+        }
+        public void ShowSecondaryWindow()
+        {
+            if (ucLogs1 != null)
+                ucLogs1.ShowSecondaryWindow();
+        }
+
+        public void HideSecondaryWindow()
+        {
+            if (ucLogs1 != null)
+                ucLogs1.HideSecondaryWindow();
         }
     }
 }

--- a/Analogy/UserControls/FilePoolingLog.cs
+++ b/Analogy/UserControls/FilePoolingLog.cs
@@ -20,11 +20,12 @@ namespace Analogy
         private string FileName { get; set; }
         public bool Enable { get; set; } = true;
         private FilePoolingManager PoolingManager { get; }
-        public FilePoolingUCLogs(IAnalogyOfflineDataProvider offlineDataProvider, string filter,  string  initialFilename, string initialFolder)
+        public FilePoolingUCLogs(IAnalogyOfflineDataProvider offlineDataProvider, string filter,  string  initialFilename, string initialFolder, string? title = null)
         {
             InitializeComponent();
             FileName = initialFilename;
             PoolingManager = new FilePoolingManager(filter, initialFilename, ucLogs1, offlineDataProvider);
+            ucLogs1.Title = title;
             ucLogs1.SetFileDataSource(offlineDataProvider, offlineDataProvider);
             ucLogs1.EnableFileReload(FileName);
 

--- a/Analogy/UserControls/FilePoolingLog.cs
+++ b/Analogy/UserControls/FilePoolingLog.cs
@@ -13,7 +13,7 @@ using Message = System.Windows.Forms.Message;
 namespace Analogy
 {
 
-    public partial class FilePoolingUCLogs : XtraUserControl
+    public partial class FilePoolingUCLogs : XtraUserControl, IUserControlWithUCLogs
     {
         private bool showHistory = UserSettingsManager.UserSettings.ShowHistoryOfClearedMessages;
         private static int clearHistoryCounter;
@@ -133,6 +133,17 @@ namespace Analogy
                 FactoriesManager.Instance, AnalogyLogger.Instance, messages, Environment.MachineName, ucLogs1.DataProvider,
                 ucLogs1.FileDataProvider);
             grid.Show(this);
+        }
+        public void ShowSecondaryWindow()
+        {
+            if (ucLogs1 != null)
+                ucLogs1.ShowSecondaryWindow();
+        }
+
+        public void HideSecondaryWindow()
+        {
+            if (ucLogs1 != null)
+                ucLogs1.HideSecondaryWindow();
         }
     }
 

--- a/Analogy/UserControls/LocalLogFilesUC.Designer.cs
+++ b/Analogy/UserControls/LocalLogFilesUC.Designer.cs
@@ -1,4 +1,5 @@
 ﻿using Analogy.UserControls;
+using DevExpress.XtraEditors;
 using DevExpress.XtraGrid.Views.Grid;
 
 namespace Analogy
@@ -39,7 +40,7 @@ namespace Analogy
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(LocalLogFilesUC));
             System.Threading.CancellationTokenSource cancellationTokenSource1 = new System.Threading.CancellationTokenSource();
-            this.spltMain = new System.Windows.Forms.SplitContainer();
+            this.spltMain = new DevExpress.XtraEditors.SplitContainerControl();
             this.splcLeft = new System.Windows.Forms.SplitContainer();
             this.folderTreeViewUC1 = new Analogy.FolderTreeViewUC();
             this.treeList1 = new DevExpress.XtraTreeList.TreeList();
@@ -97,7 +98,7 @@ namespace Analogy
             // 
             this.spltMain.Panel2.Controls.Add(this.ucLogs1);
             this.spltMain.Size = new System.Drawing.Size(1387, 700);
-            this.spltMain.SplitterDistance = 392;
+            this.spltMain.SplitterPosition = 392;
             this.spltMain.TabIndex = 5;
             // 
             // splcLeft
@@ -466,7 +467,7 @@ namespace Analogy
         }
 
         #endregion
-        private System.Windows.Forms.SplitContainer spltMain;
+        private DevExpress.XtraEditors.SplitContainerControl spltMain;
         private System.Windows.Forms.ImageList imageList;
         private System.Windows.Forms.ToolStrip tsPrimary;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;

--- a/Analogy/UserControls/LocalLogFilesUC.cs
+++ b/Analogy/UserControls/LocalLogFilesUC.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using DevExpress.Utils;
 using DevExpress.Utils.Menu;
 using DevExpress.XtraEditors;
 using DevExpress.XtraTreeList;

--- a/Analogy/UserControls/LocalLogFilesUC.cs
+++ b/Analogy/UserControls/LocalLogFilesUC.cs
@@ -26,15 +26,16 @@ namespace Analogy
         {
             InitializeComponent();
         }
-        public LocalLogFilesUC(string initSelectedPath) : this()
+        public LocalLogFilesUC(string initSelectedPath, string? title = null) : this()
         {
             SelectedPath = initSelectedPath ?? string.Empty;
             treeList1.Columns["colChanged"].SortOrder = SortOrder.Descending;
             treeList1.Appearance.HideSelectionRow.Assign(treeList1.ViewInfo.PaintAppearance.FocusedRow);
+            ucLogs1.Title = title;
             ucLogs1.SetSaveButtonsVisibility(false);
         }
 
-        public LocalLogFilesUC(IAnalogyOfflineDataProvider dataProvider, string[]? fileNames = null, string? initialSelectedPath = null) : this(initialSelectedPath ?? string.Empty)
+        public LocalLogFilesUC(IAnalogyOfflineDataProvider dataProvider, string[]? fileNames = null, string? initialSelectedPath = null, string? title = null) : this(initialSelectedPath ?? string.Empty, title: title)
         {
 
             DataProvider = dataProvider;

--- a/Analogy/UserControls/LocalLogFilesUC.cs
+++ b/Analogy/UserControls/LocalLogFilesUC.cs
@@ -15,7 +15,7 @@ using DevExpress.XtraTreeList;
 namespace Analogy
 {
 
-    public partial class LocalLogFilesUC : XtraUserControl
+    public partial class LocalLogFilesUC : XtraUserControl, IUserControlWithUCLogs
     {
         private List<string> extrenalFiles = new List<string>();
         public string SelectedPath { get; set; } = string.Empty;
@@ -247,6 +247,18 @@ namespace Analogy
             }
 
 
+        }
+
+        public void ShowSecondaryWindow()
+        {
+            if (ucLogs1 != null)
+                ucLogs1.ShowSecondaryWindow();
+        }
+
+        public void HideSecondaryWindow()
+        {
+            if (ucLogs1 != null)
+                ucLogs1.HideSecondaryWindow();
         }
     }
 

--- a/Analogy/UserControls/OnlineLog.cs
+++ b/Analogy/UserControls/OnlineLog.cs
@@ -8,7 +8,7 @@ using DevExpress.XtraEditors;
 namespace Analogy
 {
 
-    public partial class OnlineUCLogs : XtraUserControl
+    public partial class OnlineUCLogs : XtraUserControl, IUserControlWithUCLogs
     {
         private bool _showHistory = UserSettingsManager.UserSettings.ShowHistoryOfClearedMessages;
         private static int _clearHistoryCounter;
@@ -91,6 +91,17 @@ namespace Analogy
             var messages = FileProcessingManager.Instance.GetMessages((string)listBoxClearHistory.SelectedItem);
             XtraFormLogGrid grid = new XtraFormLogGrid(UserSettingsManager.UserSettings, ExtensionsManager.Instance, FactoriesManager.Instance, AnalogyLogger.Instance, messages, Environment.MachineName, ucLogs1.DataProvider, ucLogs1.FileDataProvider);
             grid.Show(this);
+        }
+        public void ShowSecondaryWindow()
+        {
+            if (ucLogs1 != null)
+                ucLogs1.ShowSecondaryWindow();
+        }
+
+        public void HideSecondaryWindow()
+        {
+            if (ucLogs1 != null)
+                ucLogs1.HideSecondaryWindow();
         }
     }
 

--- a/Analogy/UserControls/RemoteLogsUC.cs
+++ b/Analogy/UserControls/RemoteLogsUC.cs
@@ -9,7 +9,7 @@ using DevExpress.XtraEditors;
 namespace Analogy
 {
 
-    public partial class RemoteLogsUC : XtraUserControl
+    public partial class RemoteLogsUC : XtraUserControl, IUserControlWithUCLogs
     {
         private bool _showHistory = UserSettingsManager.UserSettings.ShowHistoryOfClearedMessages;
         private static int _clearHistoryCounter;
@@ -92,6 +92,18 @@ namespace Analogy
             var messages = FileProcessingManager.Instance.GetMessages((string)listBoxClearHistory.SelectedItem);
             XtraFormLogGrid grid = new XtraFormLogGrid(UserSettingsManager.UserSettings, ExtensionsManager.Instance, FactoriesManager.Instance, AnalogyLogger.Instance, messages, Environment.MachineName, ucLogs1.DataProvider, ucLogs1.FileDataProvider);
             grid.Show(this);
+        }
+
+        public void ShowSecondaryWindow()
+        {
+            if (ucLogs1 != null)
+                ucLogs1.ShowSecondaryWindow();
+        }
+
+        public void HideSecondaryWindow()
+        {
+            if (ucLogs1 != null)
+                ucLogs1.HideSecondaryWindow();
         }
     }
 


### PR DESCRIPTION
- After opening a log file, it wasn't sorted by date, particularly in case of file pooling
- file pooling only directly opening selected file, waiting for changes for reading the other files, now all matching files are read on opening
- Loggers tree extension is now by default put in dock panel on the right #1703 (that still allow me to dock it in a secondary window on a second screen for my layout)
- Left panel of offline logs was always taking a lot of space on a 2k screen (unfortunately, I wasn't able to save the with in the layout file, as it is done in a sub control).
- Pass document (tab) title to sub control, to rename secondary dock container, if any
- Switch between secondary dock container, when switching between main documents

